### PR TITLE
Replace unwrap with ? operator to avoid string parse panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-legacy-msg-data"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["AljoschaMeyer <mail@aljoscha-meyer.de>"]
 license = "AGPL-3.0"
 description = "Rust implementation of the [ssb legacy data format](https://spec.scuttlebutt.nz/feed/datamodel.html)."

--- a/src/json/de.rs
+++ b/src/json/de.rs
@@ -394,7 +394,7 @@ impl<'de> JsonDeserializer<'de> {
     }
 
     fn parse_string(&mut self) -> Result<String, DecodeJsonError> {
-        self.expect(0x22, ErrorCode::ExpectedString).unwrap();
+        self.expect(0x22, ErrorCode::ExpectedString)?;
 
         let mut decoded = String::new();
 


### PR DESCRIPTION
# Summary

This PR replaces `unwrap()` with the `?` operator to avoid panics when string parsing fails during JSON deserialization.

## Context

I'm currently running some tests on [ssb-validate](https://github.com/sunrise-choir/ssb-validate) using @christianbundy 's [SSB Validation Dataset](https://github.com/fraction/ssb-validation-dataset) and ran into a panic for three of the messages.

**The error**
```bash
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: DecodeJsonError { code: ExpectedString, position: 10 }', /home/glyph/.cargo/registry/src/github.com-1ecc6299db9ec823/ssb-legacy-msg-data-0.1.2/src/json/de.rs:397:54
```

**The origin of the panic**

https://github.com/sunrise-choir/legacy-msg-data/blob/master/src/json/de.rs#L397

**One of the offending messages**

```json
"message": {
    "previous": null,
    "sequence": 1,
    "author": 42,
    "timestamp": 1491901740000,
    "hash": "sha256",
    "content": {
        "type": "fail, author public key is invalid"
    },
    "signature": "Ly+4a83WH+mzhPuLd0+kUiGi6KWGvgsEEaA754FKAZqCvuW1guoZYzabUuygMpybOqJtdAlmOMkU5umcRA1zDA==.sig.ed25519"
}
```

**The fix**

Use the `?` operator to return the error result (`DecodeJsonError`) rather than unwrapping.