### PR TITLE
Stricter deserialization for content value

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Rust implementation of the [ssb legacy data format](https://spec.scuttlebutt.nz/feed/datamodel.html).
 
-Please be aware that this fork deviates significantly from the base repository, primarily in the strictness of the deserialization for message content values. While the base repository allows deserialization of any valid JSON value for the `content` field of a message, this implementation will fail if the `content` field is not a string or dictionary (Map). The change has been made to increase validation consistency with the JavaScript implementation of SSB.
+Please be aware that this fork deviates significantly from the base repository, primarily in the strictness of the deserialization for message content values.
+
+While the base repository allows deserialization of any valid JSON value for the `content` field of a message - provided it is in the form of a map (key-value pair), this implementation will fail if the `content` field is not a string or map (dictionary). The change has been made to increase validation consistency with the JavaScript implementation of SSB.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
 # SSB Legacy MSG Data
 
 Rust implementation of the [ssb legacy data format](https://spec.scuttlebutt.nz/feed/datamodel.html).
-
-Please be aware that this fork deviates significantly from the base repository, primarily in the strictness of the deserialization for message content values.
-
-While the base repository allows deserialization of any valid JSON value for the `content` field of a message - provided it is in the form of a map (key-value pair), this implementation will fail if the `content` field is not a string or map (dictionary). The change has been made to increase validation consistency with the JavaScript implementation of SSB.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # SSB Legacy MSG Data
 
 Rust implementation of the [ssb legacy data format](https://spec.scuttlebutt.nz/feed/datamodel.html).
+
+Please be aware that this fork deviates significantly from the base repository, primarily in the strictness of the deserialization for message content values. While the base repository allows deserialization of any valid JSON value for the `content` field of a message, this implementation will fail if the `content` field is not a string or dictionary (Map). The change has been made to increase validation consistency with the JavaScript implementation of SSB.


### PR DESCRIPTION
Validation testing with the [ssb-validation-dataset](https://github.com/fraction/ssb-validation-dataset) revealed that the Sunrise Choir implementation is less strict than the JavaScript implementation when it comes to defining what constitutes a valid message.

This PR takes steps toward closing the gap between the implementations by restricting the range of valid data types for a message content value.

While the custom deserialization implementation previously expected a map with any valid JSON type as value, this code update allows either a string (provided it contains .box) or a map of key (String) and value (any valid JSON type).

All tests for ssb-validate (rs) are passing. All tests for this repo are also passing.